### PR TITLE
Change replace signature to use only LocationDescriptor

### DIFF
--- a/react-router.d.ts
+++ b/react-router.d.ts
@@ -558,7 +558,7 @@ declare namespace ReactRouter {
 
 	type ChangeHook = (prevState: RouterState, nextState: RouterState, replace: RedirectFunction, callback?: Function) => any;
 
-	type RedirectFunction = (state: LocationState, pathname: Pathname | Path, query?: Query) => void;
+	type RedirectFunction = (pathOrLoc: LocationDescriptor) => void;
 
 	type LocationState = Object;
 


### PR DESCRIPTION
`react-router` expects a path in form of a `string` or a `LocationDescriptor` as only argument for `onEnters` replace function.

See https://github.com/ReactTraining/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors
